### PR TITLE
Dump Z3 Stats

### DIFF
--- a/include/klee/Support/FileHandling.h
+++ b/include/klee/Support/FileHandling.h
@@ -23,6 +23,9 @@ namespace klee {
 std::unique_ptr<llvm::raw_fd_ostream>
 klee_open_output_file(const std::string &path, std::string &error);
 
+std::unique_ptr<llvm::raw_fd_ostream>
+klee_append_output_file(const std::string &path, std::string &error);
+
 #ifdef HAVE_ZLIB_H
 std::unique_ptr<llvm::raw_ostream>
 klee_open_compressed_output_file(const std::string &path, std::string &error);

--- a/include/klee/Support/TimeLogger.h
+++ b/include/klee/Support/TimeLogger.h
@@ -1,0 +1,52 @@
+//===-- TimeLogger.h ----------------------------------*- C++ -*-===//
+//
+//                     The KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_TIMELOGGER_H
+#define KLEE_TIMELOGGER_H
+
+#include "klee/Statistics/Statistics.h"
+#include "klee/Support/ErrorHandling.h"
+#include "klee/Support/FileHandling.h"
+#include "klee/Support/Timer.h"
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace klee {
+
+class TimeLogger {
+private:
+  const WallTimer timer;
+  std::string filePath;
+
+public:
+  explicit TimeLogger(std::string filePath) : filePath(std::move(filePath)) {}
+  ~TimeLogger() {}
+
+  void lap(std::string status) {
+    if (filePath.empty()) {
+      return;
+    }
+    auto delta = timer.delta().toMicroseconds();
+    std::string error;
+    auto file = klee_append_output_file(filePath, error);
+    if (!file) {
+      klee_error("Could not open file %s : %s", filePath.c_str(),
+                 error.c_str());
+    }
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+    *file << now_time << "," << status << "," << delta << "\n";
+  }
+};
+} // namespace klee
+
+#endif /* KLEE_DELTATIMEDUMPER_H */

--- a/lib/Support/FileHandling.cpp
+++ b/lib/Support/FileHandling.cpp
@@ -35,6 +35,21 @@ klee_open_output_file(const std::string &path, std::string &error) {
   return f;
 }
 
+std::unique_ptr<llvm::raw_fd_ostream>
+klee_append_output_file(const std::string &path, std::string &error) {
+  error.clear();
+  std::error_code ec;
+
+  auto f = std::make_unique<llvm::raw_fd_ostream>(path.c_str(), ec,
+                                                  llvm::sys::fs::OF_Append);
+  if (ec)
+    error = ec.message();
+  if (!error.empty()) {
+    f.reset(nullptr);
+  }
+  return f;
+}
+
 #ifdef HAVE_ZLIB_H
 std::unique_ptr<llvm::raw_ostream>
 klee_open_compressed_output_file(const std::string &path, std::string &error) {


### PR DESCRIPTION

This pull request adds time-logging and statistics output capabilities to the Z3 solver integration in KLEE. It introduces a `TimeLogger` utility for recording query timings and statuses, and enables optional output of Z3 query stats and timeouts to user-specified files for easier debugging and analysis.

Key changes:

**New Logging and File Handling Utilities:**
* Added a new `TimeLogger` class in `klee/Support/TimeLogger.h` that records the elapsed time and status of Z3 queries to a CSV file. It uses a new `klee_append_output_file` function to append log entries. [[1]](diffhunk://#diff-7dd7786d8d9c79a4dd2e2de909213ae143750f1f1fd9549a97673b031581a700R1-R52) [[2]](diffhunk://#diff-2a2ad8d0e18abe89244ea23ee33fd3cd4daa1e882d0496f7dd2401f36060ebd0R26-R28) [[3]](diffhunk://#diff-4055d7009e0a1e79abadcc7ea3eac7ea7364c9caeeedd2eb8660e6bcccaeedbfR38-R52)
* Introduced the `klee_append_output_file` function in `FileHandling.h`/`.cpp` to allow appending to output files, supporting the new logging functionality. [[1]](diffhunk://#diff-2a2ad8d0e18abe89244ea23ee33fd3cd4daa1e882d0496f7dd2401f36060ebd0R26-R28) [[2]](diffhunk://#diff-4055d7009e0a1e79abadcc7ea3eac7ea7364c9caeeedd2eb8660e6bcccaeedbfR38-R52)

**Z3 Solver Statistics and Timeout Logging:**
* Added a new command-line option `--debug-z3-stats-output-dir` to specify a directory for Z3 statistics output.
* Integrated `TimeLogger` into the Z3 solver so that each query's timing and status (sat/unsat/timeout/interrupted) is logged to a CSV file in the specified directory. [[1]](diffhunk://#diff-2b1fbc05cafb2865939c32c51dd6e47542f6046b7c30ab91fab36a8d7e3b7399R260-R262) [[2]](diffhunk://#diff-2b1fbc05cafb2865939c32c51dd6e47542f6046b7c30ab91fab36a8d7e3b7399R331-R355)
* On Z3 query timeouts, the full query is dumped to a `timeout.queries` file in the stats output directory for further investigation.

**Supporting Infrastructure:**
* Added helper function `getFullFilePath` to construct output file paths in the stats directory.
* Updated includes and build dependencies to support the new features (filesystem, TimeLogger). [[1]](diffhunk://#diff-2b1fbc05cafb2865939c32c51dd6e47542f6046b7c30ab91fab36a8d7e3b7399R14) [[2]](diffhunk://#diff-2b1fbc05cafb2865939c32c51dd6e47542f6046b7c30ab91fab36a8d7e3b7399R31)