### PR TITLE
Add visualization scripts for klee stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ autom4te.cache/
 
 # Python related files
 __pycache__/
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,13 @@ repos:
       rev: v13.0.1
       hooks:
           - id: clang-format
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.14.0
+      hooks:
+          # Run the linter.
+          - id: ruff-check
+            args: [--fix]
+            files: scripts/vis/*
+          # Run the formatter.
+          - id: ruff-format
+            files: scripts/vis/*

--- a/scripts/vis/campaign-stats.py
+++ b/scripts/vis/campaign-stats.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#     "matplotlib",
+#     "pandas",
+#     "seaborn",
+#     "click",
+# ]
+# ///
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import click
+
+klee_stats_file = "lua-1.csv"
+query_stats_file = "z3-lua.csv"
+time_bucket_size = "30min"
+
+
+def match_col_name(col_name: str) -> bool:
+    if col_name == "SolverQueries":
+        return True
+    return False
+
+
+@click.group()
+def cli():
+    """Main CLI."""
+    pass
+
+
+def preprocess(klee_stats_file: str, time_bucket_size: str):
+    klee_stats = pd.read_csv(klee_stats_file)
+
+    # convert the timestamp to datetime and floor to time bucket size
+    klee_stats["WallTime"] = pd.to_timedelta(klee_stats["WallTime"], unit="us")
+    klee_stats["TimeBucket"] = klee_stats["WallTime"].dt.floor(time_bucket_size)
+    # For each time bucket, pick the row with the maximum WallTime (i.e., last in that bucket)
+    last_idx = klee_stats.groupby("TimeBucket", sort=False)["WallTime"].idxmax()
+    klee_stats = klee_stats.loc[last_idx]
+
+    # Ensure continuous time buckets with no gaps
+    min_bucket = klee_stats["TimeBucket"].min()
+    max_bucket = klee_stats["TimeBucket"].max()
+    all_buckets = pd.timedelta_range(
+        start=min_bucket, end=max_bucket, freq=time_bucket_size
+    )
+
+    # Create a complete range of time buckets and reindex
+    klee_stats = (
+        klee_stats.set_index("TimeBucket").reindex(all_buckets).fillna(0).reset_index()
+    )
+
+    # Map time buckets to sequential numbers from 0
+    klee_stats["TimeBucketNumber"] = range(len(klee_stats))
+    # Create delta columns for columns matching pattern
+    for col in klee_stats.columns:
+        if match_col_name(col):
+            delta_col_name = f"Delta{col}"
+            klee_stats[delta_col_name] = klee_stats[col].diff()
+            klee_stats.loc[0, delta_col_name] = klee_stats[col].iloc[0]
+
+    print(klee_stats.head())
+
+    return klee_stats
+
+
+@cli.command()
+@click.option("--time-bucket-size", type=str, default="30min")
+@click.argument("klee_stats_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path(exists=False))
+def bar(klee_stats_file: str, time_bucket_size: str, output_file: str):
+    klee_stats = preprocess(klee_stats_file, time_bucket_size)
+    # Plot bar chart for each column matching pattern
+    sns.barplot(x="TimeBucketNumber", y="DeltaSolverQueries", data=klee_stats)
+    plt.xticks(rotation=-45)
+    plt.savefig(output_file)
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/vis/query-stats.py
+++ b/scripts/vis/query-stats.py
@@ -1,0 +1,120 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#     "matplotlib",
+#     "pandas",
+#     "seaborn",
+#     "click",
+# ]
+# ///
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
+import click
+
+klee_stats_file = "lua-1.csv"
+query_stats_file = "z3-lua.csv"
+time_bucket_size = "30min"
+
+@click.group()
+def cli():
+    """Main CLI."""
+    pass
+
+@cli.command()
+@click.option("--time-bucket-size", type=str, default="30min")
+@click.argument("query_stats_file", type=click.Path(exists=True))
+def stats(query_stats_file, time_bucket_size):
+    query_stats = pd.read_csv(query_stats_file, header=None, names=["timestamp", "status", "span"])
+
+    # convert the timestamp to datetime and floor to time bucket size
+    query_stats["datetime"] = pd.to_datetime(query_stats["timestamp"], unit="s")
+    query_stats["time_bucket"] = query_stats["datetime"].dt.floor(time_bucket_size)
+
+    num_time_buckets = len(query_stats["time_bucket"].unique())
+
+    # count the samples of each bucket
+    counts = query_stats.groupby("time_bucket", sort=False).size().values
+
+    # print time buckets and their counts
+    time_buckets = query_stats["time_bucket"].unique()
+    for bucket, count in zip(time_buckets, counts):
+        print(f"Time bucket: {bucket}, Count: {count}")
+
+
+@cli.command()
+@click.option("--time-bucket-size", type=str, default="30min")
+@click.argument("query_stats_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path(exists=False))
+def violin(query_stats_file, time_bucket_size, output_file):
+    query_stats = pd.read_csv(query_stats_file, header=None, names=["timestamp", "status", "span"])
+
+    # convert the timestamp to datetime and floor to time bucket size
+    query_stats["datetime"] = pd.to_datetime(query_stats["timestamp"], unit="s")
+    query_stats["time_bucket"] = query_stats["datetime"].dt.floor(time_bucket_size)
+
+    num_time_buckets = len(query_stats["time_bucket"].unique())
+
+    # count the samples of each bucket
+    counts = query_stats.groupby("time_bucket", sort=False).size().values
+
+    # violin + bar
+    plt.figure(figsize=(18, 6))
+    ax = plt.gca()
+
+    # --- violin ---
+    # Use bucket_index as categorical x; dodge=True will place hue categories side-by-side
+    sns.violinplot(
+        data=query_stats,
+        x="time_bucket",
+        y=query_stats["span"] / 1000.0,
+        hue="status",
+        split=True,
+        dodge=True,
+        inner="quartile",
+        scale="width",
+        width=0.8,
+        cut=0,
+        ax=ax,
+    )
+
+    ax.set_xlabel(f"Time Buckets {time_bucket_size}")
+    ax.set_yscale("log")  # log scale for span
+    ax.set_ylabel("Query Time (millisecond)")
+
+    # x axis ticks/labels
+    ax.set_xticks(np.arange(num_time_buckets))
+    ax.set_xticklabels(np.arange(num_time_buckets))
+
+    # If there are too many ticks, thin them out to at most max_ticks
+    # max_ticks = 20
+    # if n_bins > max_ticks:
+    #     step = max(1, n_bins // max_ticks)
+    #     thin_positions = np.arange(0, n_bins, step)
+    #     ax.set_xticks(thin_positions)
+    #     ax.set_xticklabels([bin_labels[i] for i in thin_positions], rotation=45, ha="right")
+
+    # --- bar (counts) on secondary y-axis ---
+    ax2 = ax.twinx()
+    x_pos = np.arange(num_time_buckets)
+    bar_width = 0.6
+    ax2.bar(x_pos, counts, width=bar_width, alpha=0.25, color="gray", zorder=0)
+    ax2.set_ylabel("#Queries")
+
+    # Keep a single legend for the violin hue
+    # seaborn often creates its own legend; we collect legend handles from the violin axis
+    handles, labels = ax.get_legend_handles_labels()
+    if handles:
+        ax.legend(handles, labels, title="status", loc="upper right")
+    else:
+        # fallback: let matplotlib place the default legend
+        ax.legend(title="status", loc="upper right")
+
+    plt.title("Query counts (bar) + SAT/UNSAT violin of query Time")
+    plt.tight_layout()
+    plt.savefig(output_file)
+    plt.close()
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/vis/query-stats.py
+++ b/scripts/vis/query-stats.py
@@ -17,22 +17,24 @@ klee_stats_file = "lua-1.csv"
 query_stats_file = "z3-lua.csv"
 time_bucket_size = "30min"
 
+
 @click.group()
 def cli():
     """Main CLI."""
     pass
 
+
 @cli.command()
 @click.option("--time-bucket-size", type=str, default="30min")
 @click.argument("query_stats_file", type=click.Path(exists=True))
 def stats(query_stats_file, time_bucket_size):
-    query_stats = pd.read_csv(query_stats_file, header=None, names=["timestamp", "status", "span"])
+    query_stats = pd.read_csv(
+        query_stats_file, header=None, names=["timestamp", "status", "span"]
+    )
 
     # convert the timestamp to datetime and floor to time bucket size
     query_stats["datetime"] = pd.to_datetime(query_stats["timestamp"], unit="s")
     query_stats["time_bucket"] = query_stats["datetime"].dt.floor(time_bucket_size)
-
-    num_time_buckets = len(query_stats["time_bucket"].unique())
 
     # count the samples of each bucket
     counts = query_stats.groupby("time_bucket", sort=False).size().values
@@ -48,7 +50,9 @@ def stats(query_stats_file, time_bucket_size):
 @click.argument("query_stats_file", type=click.Path(exists=True))
 @click.argument("output_file", type=click.Path(exists=False))
 def violin(query_stats_file, time_bucket_size, output_file):
-    query_stats = pd.read_csv(query_stats_file, header=None, names=["timestamp", "status", "span"])
+    query_stats = pd.read_csv(
+        query_stats_file, header=None, names=["timestamp", "status", "span"]
+    )
 
     # convert the timestamp to datetime and floor to time bucket size
     query_stats["datetime"] = pd.to_datetime(query_stats["timestamp"], unit="s")
@@ -115,6 +119,7 @@ def violin(query_stats_file, time_bucket_size, output_file):
     plt.tight_layout()
     plt.savefig(output_file)
     plt.close()
+
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This pull request adds two new Python scripts for visualizing campaign and query statistics, and updates the pre-commit configuration to include automated linting and formatting for these scripts. The main changes are grouped below:

**New Visualization Scripts:**

* Added `scripts/vis/campaign-stats.py` to preprocess campaign statistics data and generate bar charts of solver queries over time buckets. The script uses `pandas`, `matplotlib`, `seaborn`, and `click` for data handling and visualization, and supports CLI commands for flexible usage.
* Added `scripts/vis/query-stats.py` to analyze and visualize query statistics, including time bucket counts and violin plots of query times split by status. The script also uses `pandas`, `matplotlib`, `seaborn`, `numpy`, and `click`, and provides CLI commands for stats summary and violin plot generation.

**Development Workflow Improvements:**

* Updated `.pre-commit-config.yaml` to add the `ruff-pre-commit` repository, enabling automatic linting (`ruff-check`) and formatting (`ruff-format`) for files in the `scripts/vis/` directory. This ensures code quality and consistent style for the new scripts.